### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=IBM
 maintainer=Matthijs Kooijman <matthijs@stdin.nl> and Thomas Telkamp <thomas@telkamp.eu>
 sentence=Arduino port of LoRaWAN C-library (LMiC) v1.5 framework provided by IBM.
 paragraph=Supports SX1272/SX1276 and HopeRF RFM92/RFM95 tranceivers
+category=Communication
 url=http://www.research.ibm.com/labs/zurich/ics/lrsc/lmic.html
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library IBM LMIC framework v1.5 for Arduino is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
